### PR TITLE
[Feature Request] Start Vote API Handler

### DIFF
--- a/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
+++ b/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
@@ -6,9 +6,4 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="CounterStrikeSharp.API" Version="1.0.253" />
-    </ItemGroup>
-
 </Project>

--- a/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
+++ b/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
@@ -6,4 +6,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CounterStrikeSharp.API" Version="1.0.253" />
+    </ItemGroup>
+
 </Project>

--- a/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
+++ b/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>CS2_CustomVotes.Shared</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
+
     <ItemGroup>
       <PackageReference Include="CounterStrikeSharp.API" Version="1.0.253" />
     </ItemGroup>
+
 </Project>

--- a/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
+++ b/CS2-CustomVotes.Shared/CS2-CustomVotes.Shared.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>CS2_CustomVotes.Shared</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-
     <ItemGroup>
       <PackageReference Include="CounterStrikeSharp.API" Version="1.0.253" />
     </ItemGroup>
-
 </Project>

--- a/CS2-CustomVotes.Shared/ICustomVoteApi.cs
+++ b/CS2-CustomVotes.Shared/ICustomVoteApi.cs
@@ -9,5 +9,6 @@ public interface ICustomVoteApi
 
     public void AddCustomVote(string name, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
     public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
+    public void StartCustomVote(CCSPlayerController? player, string name);
     public void RemoveCustomVote(string name);
 }

--- a/CS2-CustomVotes.Shared/ICustomVoteApi.cs
+++ b/CS2-CustomVotes.Shared/ICustomVoteApi.cs
@@ -1,4 +1,5 @@
-﻿using CS2_CustomVotes.Shared.Models;
+﻿using CounterStrikeSharp.API.Core;
+using CS2_CustomVotes.Shared.Models;
 
 namespace CS2_CustomVotes.Shared;
 

--- a/CS2-CustomVotes.Shared/ICustomVoteApi.cs
+++ b/CS2-CustomVotes.Shared/ICustomVoteApi.cs
@@ -1,5 +1,4 @@
-﻿using CounterStrikeSharp.API.Core;
-using CS2_CustomVotes.Shared.Models;
+﻿using CS2_CustomVotes.Shared.Models;
 
 namespace CS2_CustomVotes.Shared;
 

--- a/CS2-CustomVotes.Shared/ICustomVoteApi.cs
+++ b/CS2-CustomVotes.Shared/ICustomVoteApi.cs
@@ -7,6 +7,7 @@ public interface ICustomVoteApi
 {
     public void AddCustomVote(string name, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style);
     public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style);
+
     public void AddCustomVote(string name, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
     public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
     public void StartCustomVote(CCSPlayerController? player, string name);

--- a/CS2-CustomVotes.Shared/ICustomVoteApi.cs
+++ b/CS2-CustomVotes.Shared/ICustomVoteApi.cs
@@ -9,6 +9,5 @@ public interface ICustomVoteApi
 
     public void AddCustomVote(string name, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
     public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
-    public void StartCustomVote(CCSPlayerController? player, string name);
     public void RemoveCustomVote(string name);
 }

--- a/CS2-CustomVotes.Shared/ICustomVoteApi.cs
+++ b/CS2-CustomVotes.Shared/ICustomVoteApi.cs
@@ -7,7 +7,6 @@ public interface ICustomVoteApi
 {
     public void AddCustomVote(string name, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style);
     public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style);
-
     public void AddCustomVote(string name, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
     public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote, Dictionary<string, VoteOption> options, string style, int minVotePercentage);
     public void StartCustomVote(CCSPlayerController? player, string name);

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -34,17 +34,6 @@ public class CustomVoteApi : ICustomVoteApi
         _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
     }
 
-    public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote,
-        Dictionary<string, VoteOption> options, string style, int minVotePercentage)
-    {
-        _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
-    }
-
-    public void StartCustomVote(CCSPlayerController? player, string name, out string baseName)
-    {
-        _voteManager.StartVote(player, name, out string baseName);
-    }
-
     public void RemoveCustomVote(string name)
     {
         _voteManager.RemoveVote(name);

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -34,6 +34,17 @@ public class CustomVoteApi : ICustomVoteApi
         _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
     }
 
+    public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote,
+        Dictionary<string, VoteOption> options, string style, int minVotePercentage)
+    {
+        _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
+    }
+
+    public void StartCustomVote(CCSPlayerController? player, string name, out string baseName)
+    {
+        _voteManager.StartVote(player, name, out string baseName);
+    }
+
     public void RemoveCustomVote(string name)
     {
         _voteManager.RemoveVote(name);

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -1,4 +1,6 @@
 ﻿using CS2_CustomVotes.Shared;
+﻿using CounterStrikeSharp.API;
+﻿using CounterStrikeSharp.API.Core;
 using CS2_CustomVotes.Shared.Models;
 
 namespace CS2_CustomVotes.Services;

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -40,10 +40,9 @@ public class CustomVoteApi : ICustomVoteApi
         _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
     }
 
-    public void StartCustomVote(CCSPlayerController? player, string name)
+    public void StartCustomVote(CCSPlayerController? player, string name, out string baseName)
     {
-        string baseName = "";
-        string result = _voteManager.StartVote(player, name, out string baseName);
+        _voteManager.StartVote(player, name, out string baseName);
     }
 
     public void RemoveCustomVote(string name)

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -40,9 +40,10 @@ public class CustomVoteApi : ICustomVoteApi
         _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
     }
 
-    public void StartCustomVote(CCSPlayerController? player, string name, out string baseName)
+    public void StartCustomVote(CCSPlayerController? player, string name)
     {
-        _voteManager.StartVote(player, name, out string baseName);
+        string baseName = "";
+        string result = _voteManager.StartVote(player, name, out string baseName);
     }
 
     public void RemoveCustomVote(string name)

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -1,6 +1,4 @@
 ﻿using CS2_CustomVotes.Shared;
-﻿using CounterStrikeSharp.API;
-﻿using CounterStrikeSharp.API.Core;
 using CS2_CustomVotes.Shared.Models;
 
 namespace CS2_CustomVotes.Services;

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -1,6 +1,5 @@
 ﻿using CS2_CustomVotes.Shared;
-﻿using CounterStrikeSharp.API;
-﻿using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core;
 using CS2_CustomVotes.Shared.Models;
 
 namespace CS2_CustomVotes.Services;
@@ -36,16 +35,9 @@ public class CustomVoteApi : ICustomVoteApi
         _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
     }
 
-    public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote,
-        Dictionary<string, VoteOption> options, string style, int minVotePercentage)
-    {
-        _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
-    }
-
     public void StartCustomVote(CCSPlayerController? player, string name)
     {
-        string baseName = "";
-        string result = _voteManager.StartVote(player, name, out string baseName);
+        bool result = _voteManager.StartVote(player, name, out string baseName);
     }
 
     public void RemoveCustomVote(string name)

--- a/CS2-CustomVotes/Services/CustomVoteApi.cs
+++ b/CS2-CustomVotes/Services/CustomVoteApi.cs
@@ -1,5 +1,6 @@
 ﻿using CS2_CustomVotes.Shared;
-using CounterStrikeSharp.API.Core;
+﻿using CounterStrikeSharp.API;
+﻿using CounterStrikeSharp.API.Core;
 using CS2_CustomVotes.Shared.Models;
 
 namespace CS2_CustomVotes.Services;
@@ -35,9 +36,16 @@ public class CustomVoteApi : ICustomVoteApi
         _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
     }
 
+    public void AddCustomVote(string name, List<string> aliases, string description, string defaultOption, float timeToVote,
+        Dictionary<string, VoteOption> options, string style, int minVotePercentage)
+    {
+        _voteManager.AddVote(name, aliases, description, defaultOption, timeToVote, options, style, minVotePercentage);
+    }
+
     public void StartCustomVote(CCSPlayerController? player, string name)
     {
-        bool result = _voteManager.StartVote(player, name, out string baseName);
+        string baseName = "";
+        string result = _voteManager.StartVote(player, name, out string baseName);
     }
 
     public void RemoveCustomVote(string name)


### PR DESCRIPTION
Hey there! I have a fork of your repository and was experimenting with the ability to create my own menus that will then trigger CS2-CustomVotes created via the Shared API. By adding the StartVote method to the Shared API I was able to accomplish this and thought it may be a good addition to your repository upon your approval. 

For some context, I am currently using this in my [GameModeManager](https://github.com/nickj609/GameModeManager/tree/main) plugin in an unofficial release. I generate a list of maps and game modes that I then create custom votes for. I have a command !game that all players can use to see a menu of player commands, many of which are commands generated by creating the custom votes via the Shared API. When users are presented with these menus they can enter the number !1 to select the option.

Before this implementation, it would respond with `Say !<vote name> to start a vote`.  Now, as expected, it will trigger the vote. 